### PR TITLE
Emit ES2015 code

### DIFF
--- a/support/tsconfig.json
+++ b/support/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2015",
     "module": "commonjs",
-    "lib": [ "es2017" ],
+    "lib": [ "es2015.collection", "es2015", "dom" ], // Not sure what is needed - pulled these from here https://github.com/API-market/machinomy-contracts/commit/8977876de0b167be65240243856c682698e9f08a
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@machinomy"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "ES2015",
     "module": "commonjs",
-    "lib": [ "es2017" ],
+    "lib": [ "es2015.collection", "es2015", "dom" ], // Not sure what is needed - pulled these from here https://github.com/API-market/machinomy-contracts/commit/8977876de0b167be65240243856c682698e9f08a
     "sourceMap": true,          // Generate corresponding '.map' file
     "declaration": true,        // Generate corresponding '.d.ts' file
     "strict": true,             // Enable all strict type-checking options


### PR DESCRIPTION
Changed output of typescript compiles to target ES6 / ES2015. Needed to support older version of Node (6.10) for Amazon and Google Cloud functions. 